### PR TITLE
reviewed-by: allow +1 next to lgtm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ Example usage:
 ```
 git-apply-pr joyent/node#1337
 ```
+
+To include support for using `+1` as a valid vote in favor of merging a pull request, you can use the `--plusone` command line switch like following:
+
+```
+git-apply-pr --plusone apache/couchdb-fauxton#321
+```


### PR DESCRIPTION
use case: in apache projects we usually vote by a `+1` and never
by a `lgtm`

if the patch is making the tool unusable for node, I can make it configurable
