### PR TITLE
http-client: use location header

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ the PR-url.
 Example usage:
 
 ```
-git-apply-pr joyent/node#1337
+git-apply-pr joyent/git-apply-pr#4
 ```

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "apply-pr.js",
   "dependencies": {
     "github": "~0.2.3",
-    "lstream": "~0.0.4"
+    "lstream": "~0.0.4",
+    "request": "~2.55.0"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
GitHub decided recently to host patches on another domain
(githubusercontent) so we have to follow the sent location header.

closes #6
