### PR TITLE
support landing PRs with more than one commit

### DIFF
--- a/apply-pr.js
+++ b/apply-pr.js
@@ -222,9 +222,11 @@ Mutator.prototype._transform = function mutatorTransform(chunk, encoding, done) 
       }
       break;
     case 'BODY':
-      if (/^From /.test(chunk))
+      if (/^From /.test(chunk)) {
+        // Process the next commit in this PR
         this.m_state = 'HEADER';
-      else {
+        this.m_message = [];
+      } else {
         this.push(chunk + os.EOL);
         done();
         return;


### PR DESCRIPTION
Currently, when using git-apply-pr to land pull requests that contain
more than one commit, git am complains about the format of the input.

The reason is that when processing subsequent commits, the current
message is not cleared in the Mutator transform stream.

This change clears the message when moving on to the next commit, and
allows to land PRs with multiple commits.
