### PR TITLE
omit email if no email given

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -1,5 +1,6 @@
 var util = require('util');
 var os = require('os');
+var assert = require('assert');
 
 var Transform = require('stream').Transform;
 
@@ -76,11 +77,17 @@ function maybeTestForPlusOne(config, comment) {
 
 exports.formatReviewedByMetaData = formatReviewedByMetaData;
 function formatReviewedByMetaData(reviewer) {
-  if (!reviewer.email) {
-    return util.format('%s', reviewer.name);
+  var formattedComponents = [];
+
+  assert(typeof (reviewer.name) === 'string', 'reviewer name must be a string');
+
+  formattedComponents.push(util.format('%s', reviewer.name));
+
+  if (reviewer.email) {
+    formattedComponents.push(util.format('<%s>', reviewer.email));
   }
 
-  return util.format('%s <%s>', reviewer.name, reviewer.email);
+  return formattedComponents.join(' ').trim();
 }
 
 function formatPRMetaData(prInfo) {

--- a/lib/lib.js
+++ b/lib/lib.js
@@ -74,7 +74,12 @@ function maybeTestForPlusOne(config, comment) {
   return /\+1/.test(comment);
 }
 
+exports.formatReviewedByMetaData = formatReviewedByMetaData;
 function formatReviewedByMetaData(reviewer) {
+  if (!reviewer.email) {
+    return util.format('%s', reviewer.name);
+  }
+
   return util.format('%s <%s>', reviewer.name, reviewer.email);
 }
 

--- a/test/formatters.js
+++ b/test/formatters.js
@@ -1,0 +1,15 @@
+var tap = require('tap');
+
+var lib = require('../lib/lib.js');
+
+tap.test('formats the reviewer name and email', function (t) {
+  var res = lib.formatReviewedByMetaData({name: 'Kerstin', email: 'uschi@example.com'});
+  t.equal('Kerstin <uschi@example.com>', res);
+  t.end();
+});
+
+tap.test('omits the email if no email given', function (t) {
+  var res = lib.formatReviewedByMetaData({name: 'Kerstin'});
+  t.equal('Kerstin', res);
+  t.end();
+});


### PR DESCRIPTION
I recently run into #1 which I found super annoying as I already pushed the commit:

https://github.com/whatwg/console/commit/139ef013b0c82a8ba11d03cc19eced1191fe7816

So I tweaked `git-apply-pr` a bit:

If the user did not provide an email address, we are just adding
the name. Previously we were adding `<null>`  if no email address
was provided, example:

```
Reviewed-By: Mr. Foo Bert <null>
```

New behaviour:

```
Reviewed-By: Mr. Foo Bert
```

@misterdjules after thinking about it I think this way might be even better than failing / force flags as discussed in #14 -- what do you think?
