### PR TITLE
`lib.authenticate` is not exported, authentication method deprecated.

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -15,6 +15,7 @@ var github = new (require('github'))({
   },
 });
 
+exports.authenticate = authenticate;
 function authenticate(token) {
   github.authenticate({
     type: 'token',


### PR DESCRIPTION
On a fresh clone of the tool, I ran into the following error:

```
$ git-apply-pr joyent/sdc#190

/usr/local/lib/node_modules/git-apply-pr/apply-pr.js:95
    authenticate(match[1]);
    ^
TypeError: undefined is not a function
```

Upon inspection, the cause is clear: `authenticate` is not included in the exports from `lib/lib.js`.

I believe that the existing integration tests should cover correct authentication, but I ran into further problems:

```
$ node ./apply-pr.js --plusone apache/couchdb-fauxton#321
{ [Error: {"message":"Bad credentials","documentation_url":"https://developer.github.com/v3"}]
  message: '{"message":"Bad credentials","documentation_url":"https://developer.github.com/v3"}',
  code: 401 }
```

And according to the [node-github docs](https://github.com/mikedeboer/node-github#authentication), it appears that the token authentication is deprecated and no longer supported by v3 of Github's API.
